### PR TITLE
Add basic Web (PHP) front-end page

### DIFF
--- a/Web-PHP/README.md
+++ b/Web-PHP/README.md
@@ -1,0 +1,15 @@
+To utilize this Web-PHP front-end:
+
+1. `SimSat` script must be located at `/usr/local/SimSat/SimSat`
+  * Most easily accomplished via `$ sudo cd /usr/local && git clone https://github.com/akhepcat/SimSat.git`
+2. Install Apache2 and PHP5
+  * `$ sudo apt-get install apache2 php5 libapache2-mod-php5`
+3. Add the following lines to sudoers (run `$ visudo`)
+
+```
+Defaults        env_keep += "DELAY"
+Defaults        env_keep += "LOSS"
+Defaults        env_keep += "CORRUPT"
+Defaults        env_keep += "RATE"
+www-data ALL = NOPASSWD: /usr/local/SimSat/SimSat
+```

--- a/Web-PHP/README.md
+++ b/Web-PHP/README.md
@@ -4,7 +4,8 @@ To utilize this Web-PHP front-end:
   * Most easily accomplished via `$ sudo cd /usr/local && git clone https://github.com/akhepcat/SimSat.git`
 2. Install Apache2 and PHP5
   * `$ sudo apt-get install apache2 php5 libapache2-mod-php5`
-3. Add the following lines to sudoers (run `$ visudo`)
+3. Copy or move `index.php` to `/var/www/html` and verify it is readable/executable by the www-data user
+4. Add the following lines to sudoers (run `$ visudo`)
 
 ```
 Defaults        env_keep += "DELAY"

--- a/Web-PHP/index.php
+++ b/Web-PHP/index.php
@@ -1,0 +1,129 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>SimSat</title>
+  <!-- jQuery -->
+  <script src="https://code.jquery.com/jquery-3.1.0.min.js"></script>
+
+  <!-- Bootstrap -->
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+  <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+  
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+</head>
+<body>
+<?php
+
+# If submitted, set new values
+if( ! empty( $_GET ) ){
+  if(
+    is_numeric( $_GET['delay'] ) &&
+    is_numeric( $_GET['delayPlusMinus'] ) &&
+    is_numeric( $_GET['loss'] ) &&
+    is_numeric( $_GET['lossPlusMinus'] ) &&
+    is_numeric( $_GET['corrupt'] ) &&
+    is_numeric( $_GET['rate'] )
+  ){
+    # Delay, Loss, and Corrupt are halved as they occur twice (in & out).
+    $delayVar = "delay ".sprintf( "%f", ( (float) $_GET['delay'] )/2)."ms ".sprintf( "%f", ( (float) $_GET['delayPlusMinus'])/2)."ms distribution normal";
+    $lossVar = "loss ".sprintf( "%f", ( (float) $_GET['loss'] )/2)."% ".sprintf( "%f", ( (float) $_GET['lossPlusMinus'])/2)."%";
+    $corruptVar = "corrupt ".sprintf( "%f", ( (float) $_GET['corrupt'] )/2)."%";
+    $rateVar = $_GET['rate'].$_GET['rateUnit'];
+
+    $simsatPath = "/usr/local/SimSat/SimSat";
+    $cmdVarsStr = "DELAY=\"$delayVar\" LOSS=\"$lossVar\" CORRUPT=\"$corruptVar\" RATE=\"$rateVar\" ";
+
+    $result = exec( "sudo $simsatPath stop", $output );
+    $result = exec( "sudo $cmdVarsStr $simsatPath start", $output );
+  }
+}
+
+# Defaults
+
+$cfg['delay']          = "600";
+$cfg['delayPlusMinus'] = "10";
+$cfg['loss']           = "1";
+$cfg['lossPlusMinus']  = "25";
+$cfg['corrupt']        = "1";
+$cfg['rate']           = "15";
+$cfg['rateUnit']      = "mbps";
+
+# READ IN EXISTING VALUES
+
+$out = exec( "/usr/local/SimSat/SimSat status", $output, $status );
+
+foreach( $output as $line ){
+  # Read in rate setting
+  if( "class hfsc 1:1 parent" == substr( $line, 0, 21 ) ){
+    $tmp = explode( " ", $line );
+    $arr = preg_split( '/(?<=[0-9])(?=[a-z]+)/i', array_pop( $tmp ) );
+    $cfg['rate'] = $arr[0];
+    $cfg['rateUnit'] = strtolower( $arr[1] );
+  }
+  # Read in delay, loss, and corrupt settings
+  if( "qdisc netem 10: parent 1:1 limit" == substr( $line, 0, 32 ) ){
+    $tmp = explode( " ", $line );
+    
+    # Delay, Loss, and Corrupt are halved as they occur twice (in & out).
+    # The displayed values are the totals (human readable), not the actual settings
+    $cfg['delay'] = ( (int) trim( $tmp[8], 'ms' ) ) * 2;
+    $cfg['delayPlusMinus'] = ( (int) trim( $tmp[10], 'ms' ) ) * 2;
+    $cfg['loss'] = ( (float) trim( $tmp[12], '%' ) ) * 2;
+    $cfg['lossPlusMinus'] = ( (float) trim( $tmp[13], '%' ) ) * 2;
+    $cfg['corrupt'] = ( (float) trim( $tmp[15], '%' ) ) *2;
+  }
+}
+
+?>
+
+<div class="container-fluid">
+  <div class="row">
+    <form method="get" role="form">
+     <div class="form-group">
+      <div class="col-md-1">
+        <label for="delay">Delay</label>
+        <input class="form-control" type="text" name="delay" value="<?php echo $cfg['delay']; ?>" /> ms
+      </div>
+      <div class="col-md-1">
+        <label for="delayPlusMinus">Delay +/-</label>
+        <input class="form-control" type="text" name="delayPlusMinus" value="<?php echo $cfg['delayPlusMinus']; ?>" /> ms
+      </div>
+      <div class="col-md-1">
+        <label for="loss">Loss</label>
+        <input class="form-control" type="text" name="loss" value="<?php echo sprintf( "%f", $cfg['loss'] ); ?>" /> %
+      </div>
+      <div class="col-md-1">
+        <label for="lossPlusMinus">Loss +/-</label>
+        <input class="form-control" type="text" name="lossPlusMinus" value="<?php echo $cfg['lossPlusMinus']; ?>" /> %
+      </div>
+      <div class="col-md-2">
+        <label for="corrupt">Corrupt</label>
+        <input class="form-control" type="text" name="corrupt" value="<?php echo sprintf( "%f", $cfg['corrupt'] ); ?>" /> %
+      </div>
+      <div class="col-md-1">
+        <label for="rate">Rate</label>
+        <input class="form-control" type="text" name="rate" value="<?php echo $cfg['rate']; ?>" />
+      </div>
+      <div class="col-md-1">
+        <label for="rateInput">Rate units</label>
+        <select class="form-control" name="rateUnit">
+          <option value="kbps"<?php echo ( $cfg['rateUnit'] == "kbps" ? " selected='selected'" : ""); ?>>kbps (Kilobytes per second)</option>
+          <option value="mbps"<?php echo ( $cfg['rateUnit'] == "mbps" ? " selected='selected'" : ""); ?>>mbps (Megabytes per second)</option>
+          <option value="kbit"<?php echo ( $cfg['rateUnit'] == "kbit" ? " selected='selected'" : ""); ?>>kbit (Kilobits per second)</option>
+          <option value="mbit"<?php echo ( $cfg['rateUnit'] == "mbit" ? " selected='selected'" : ""); ?>>mbit (Megabits per second)</option>
+          <option value="bps"<?php echo ( $cfg['rateUnit'] == "bps" ? " selected='selected'" : ""); ?>>bps (Bytes per second)</option>
+        </select>
+      </div>
+      <div class="col-md-1">
+        <label for=""></label>
+        <input class="form-control" type="submit" value="Update" />
+      </div>
+     </div>
+    </form>
+  
+  </div>
+</div>
+
+</body>
+</html>


### PR DESCRIPTION
Adds a single page web front-end to view and configure SimSat.

There is minimal validation or customization currently, but for many environments this will suffice.
